### PR TITLE
fix: 修复人脸认证过程中切换至密码认证再切回,概率性提示get driver error问题

### DIFF
--- a/drivermanger.cpp
+++ b/drivermanger.cpp
@@ -135,8 +135,9 @@ void DriverManger::verifyStop(QString actionId, ErrMsgInfo &errMsgInfo)
     }
 
     m_bClaim = false;
-    ModelManger::getSingleInstanceModel().unLoad();
+    // 线程结束后才释放资源
     m_spVerifyThread->Stop();
+    ModelManger::getSingleInstanceModel().unLoad();
     m_actionMap.remove(actionId);
 }
 

--- a/workmodule.h
+++ b/workmodule.h
@@ -13,6 +13,10 @@
 #include <QPixmap>
 #include <QThread>
 
+QT_BEGIN_NAMESPACE
+class QMutex;
+QT_END_NAMESPACE
+
 class DriverManger;
 class ErollThread : public QThread
 {
@@ -34,6 +38,7 @@ private:
     bool m_bFirst;
 };
 
+
 class VerifyThread : public QThread
 {
 public:
@@ -50,6 +55,7 @@ private:
     QString m_actionId;
     bool m_bRun;
     QVector<float *> m_charaDatas;
+    QSharedPointer<QMutex> m_mutex;
 };
 
 #endif // WORKMODULE_H


### PR DESCRIPTION
调用验证停止时,提前释放了seetaface对象,导致空指针崩溃
改进为等待全部验证结束再释放seetaface对象

Log: 人脸验证优化
Bug: https://pms.uniontech.com/bug-view-151599.html
Influence: 人脸验证录入
Change-Id: I6f2d6eb6204181d57814abd6216c64482e1f5371