### PR TITLE
 fix: 修复无法录入人脸数据的问题

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,6 +38,7 @@ Depends: ${shlibs:Depends},
 	  seetaface-pose-estimation,
 	  seetaface-authorize,
 	  seetaface-tennis,
-	  seetaface-models
+	  seetaface-models,
+	  libqt5multimedia5-plugins
 Description: Face recognition service 
  deepin-face is a face recognition service implemented by the open source face recognition engine seetaface


### PR DESCRIPTION
由于系统删除了之前的预装包libqt5multimedia5-plugins，导致QCameraInfo::availableCameras()拿不到可用摄像头，所以人脸服务无法打开摄像头导致

添加libqt5multimedia5-plugins依赖保证功能可用

Log: 添加libqt5multimedia5-plugins依赖保证设备信息获取正常
Influence: 人脸服务录入等功能正常
Bug: https://pms.uniontech.com/bug-view-141827.html