### PR TITLE
fix: 修复接口调用录入时可能导致服务无法退出问题

### DIFF
--- a/drivermanger.cpp
+++ b/drivermanger.cpp
@@ -13,6 +13,14 @@ DriverManger::DriverManger()
     , m_verify(new QThread(this))
 {
 }
+
+DriverManger::~DriverManger()
+{
+    m_eroll->quit();
+    m_eroll->wait(1000);
+    m_verify->quit();
+    m_verify->wait(1000);
+}
 void DriverManger::init()
 {
     m_spFileWatch = QSharedPointer<QFileSystemWatcher>(new QFileSystemWatcher(this));

--- a/drivermanger.h
+++ b/drivermanger.h
@@ -41,6 +41,7 @@ class DriverManger : public QObject, public QEnableSharedFromThis<DriverManger>
     Q_OBJECT
 public:
     DriverManger();
+    virtual ~DriverManger();
     void init();
     QDBusUnixFileDescriptor enrollStart(QString chara,
                                         qint32 charaType,

--- a/workmodule.h
+++ b/workmodule.h
@@ -50,6 +50,7 @@ private:
     QString m_actionId;
     int m_fileSocket;
     bool m_bFirst;
+    bool m_stopCapture;
 };
 
 


### PR DESCRIPTION
加入接口调用录入时退出标识符判断

Log: 加入接口调用录入时退出标识符判断
Influence: 控制中心生物识别人脸录入、人脸数据管理及鉴权人脸对比验证等
Task: https://pms.uniontech.com/task-view-206871.html
Change-Id: I2ef31a280ded53d8e3360642dfafe750acad18d8