### PR TITLE
fix: deepin-face出现崩溃

### DIFF
--- a/workmodule.cpp
+++ b/workmodule.cpp
@@ -465,7 +465,10 @@ void VerifyThread::processCapturedImage(int id, const QImage &preview)
 void VerifyThread::Stop()
 {
     qDebug() << "VerifyThread::Stop thread:" << QThread::currentThreadId();
+
     m_imageCapture->cancelCapture();
+    // 当关闭相机后, 会取消图片的抓取, 此时不需要去处理抓取的图片
+    disconnect(m_imageCapture.data(), &QCameraImageCapture::imageCaptured, this, &VerifyThread::processCapturedImage);
     m_camera->stop();
     m_camera->unload();
     for (int i = 0; i < m_charaDatas.size(); i++) {


### PR DESCRIPTION
相机的库有更新(相比v20), 在取消抓取后, 依然会发出图片抓取的信号, 而此时deepin-face的相关资源已经释放 此时处理图片会访问空指针, 导致coredump.因此, 在结束人脸录入时,取消图片抓取后,不再处理抓取的图片

Log: 修复deepin-face出现崩溃的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/3699
Influence: 控制中心人脸录入