### PR TITLE
fit: Camera occupied with no feedback

### DIFF
--- a/workmodule.cpp
+++ b/workmodule.cpp
@@ -122,7 +122,7 @@ void ErollThread::readyForCapture(bool ready)
 
 void ErollThread::captureError(int err, QImageCapture::Error, const QString &errorString)
 {
-    if (err > 0) {
+    if (m_camera->error() != QCamera::NoError) {
         qDebug() << "read camera fail:" << errorString;
         Q_EMIT processStatus(m_actionId, FaceEnrollException);
     }
@@ -330,7 +330,7 @@ void VerifyThread::readyForCapture(bool ready)
 
 void VerifyThread::captureError(int err, QImageCapture::Error, const QString &errorString)
 {
-    if (err > 0) {
+    if (m_camera->error() != QCamera::NoError) {
         qDebug() << "read camera fail:" << errorString;
         Q_EMIT processStatus(m_actionId, FaceEnrollException);
     }


### PR DESCRIPTION
QT6 multimedia mechanism changes result in unprocessed corresponding scenes

pms: BUG-309895

## Summary by Sourcery

Update camera error handling in QT6 multimedia to correctly detect and report camera errors

Bug Fixes:
- Fix camera error detection mechanism to use QCamera::error() instead of checking error value directly

Enhancements:
- Improve error reporting for camera capture failures in QT6 multimedia framework