### PR TITLE
chore: bump version to 2.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-face (2.0.8) unstable; urgency=medium
+
+  * fit: Camera occupied with no feedback
+
+ -- Lv Peilong <lvpeilong@uniontech.com>  Thu, 10 Apr 2025 19:46:05 +0800
+
 deepin-face (2.0.7) unstable; urgency=medium
 
   * fix: 修复人脸录入过程中,关闭窗口后,人脸设备未即时退出问题


### PR DESCRIPTION
bump version to 2.0.8

## Summary by Sourcery

Chores:
- Bump project version to 2.0.8 in the Debian changelog file