### PR TITLE
chore: bump version to 2.0.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-face (2.0.9) unstable; urgency=medium
+
+  * feat: add Debian packaging configuration
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 09 Jul 2025 16:48:33 +0800
+
 deepin-face (2.0.8) unstable; urgency=medium
 
   * fit: Camera occupied with no feedback


### PR DESCRIPTION
update changelog to 2.0.9

## Summary by Sourcery

Build:
- Bump Debian changelog entry to version 2.0.9