### PR TITLE
chore: bump version to 2.0.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-face (2.0.10) unstable; urgency=medium
+
+  * chore: change license from LGPL to GPL
+  * fix: improve enrollment stop sequence and thread safety
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 16 Oct 2025 20:49:50 +0800
+
 deepin-face (2.0.9) unstable; urgency=medium
 
   * feat: add Debian packaging configuration


### PR DESCRIPTION
update changelog to 2.0.10

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 2.0.10