### PR TITLE
chore: update copyright year and improve image scaling

### DIFF
--- a/workmodule.cpp
+++ b/workmodule.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -144,10 +144,19 @@ void ErollThread::processCapturedImage(int id, const QImage &preview)
         return;
 
     QImage img;
-    if (preview.size() == QSize(800, 600))
+    if (preview.size() == QSize(800, 600)) {
         img = preview;
-    else
-        img = preview.scaled(QSize(800, 600));
+    } else {
+        const int pw = preview.width();
+        const int ph = preview.height();
+        double scale = qMax(800.0 / pw, 600.0 / ph);
+        int srcW = qRound(800.0 / scale);
+        int srcH = qRound(600.0 / scale);
+        int srcX = (pw - srcW) / 2;
+        int srcY = (ph - srcH) / 2;
+        img = preview.copy(srcX, srcY, srcW, srcH)
+                    .scaled(800, 600, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+    }
 
     if (1 == id) {
         sendCapture(img);


### PR DESCRIPTION
Updated the copyright year range from 2022 to 2022-2026 in the file header.
Modified the image scaling logic in ErollThread::processCapturedImage to use center-cropping instead of simple scaling when the preview image size is not 800x600. This ensures the captured image maintains its aspect ratio and focuses on the central region, preventing distortion that could occur with non-uniform scaling. The new method calculates the appropriate source rectangle based on the larger required scale factor, crops from the center, and then scales to the target dimensions.

chore: 更新版权年份并改进图像缩放

更新了文件头中的版权年份范围，从2022年改为2022-2026年。
修改了ErollThread::processCapturedImage中的图像缩放逻辑，当预览图像尺寸 不是800x600时，使用中心裁剪代替简单的缩放。这确保了捕获的图像保持其宽高
比并聚焦于中央区域，防止了非均匀缩放可能导致的失真。新方法根据所需的最大
缩放因子计算适当的源矩形，从中心裁剪，然后缩放到目标尺寸。

PMS: BUG-304729

## Summary by Sourcery

Update copyright metadata and refine captured image processing to avoid distorted previews.

Bug Fixes:
- Adjust captured image processing to use center-cropping and scaling so non-800x600 previews maintain aspect ratio without distortion.

Chores:
- Update file header copyright year range from 2022 to 2022-2026.