### PR TITLE
chore: update changelog to 2.0.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-face (2.0.11) unstable; urgency=medium
+
+  * chore: update copyright year and improve image scaling
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 18 Mar 2026 14:17:18 +0800
+
 deepin-face (2.0.10) unstable; urgency=medium
 
   * chore: change license from LGPL to GPL


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.11

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.11
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.11.