### PR TITLE
chore: update changelog to 20260528142155

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-face (20260528142155) unstable; urgency=medium
+
+  * fix: prevent capture stuck on null images
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 28 May 2026 14:21:58 +0800
+
 deepin-face (2.0.12) unstable; urgency=medium
 
   * fix: resolve face enrollment freeze issue


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 20260528142155

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 20260528142155
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog metadata to the new release version 20260528142155.