### PR TITLE
fix: tighten DBus policy to restrict direct access to Face1 sensitive methods

### DIFF
--- a/msic/dbus-conf/org.deepin.dde.Face1.conf
+++ b/msic/dbus-conf/org.deepin.dde.Face1.conf
@@ -10,14 +10,28 @@
     <allow own="org.deepin.dde.Face1"/>
   </policy>
 
-  <!-- Allow anyone to invoke methods on the interfaces -->
+  <!-- Default: deny all Face1 methods, allow standard dbus interfaces -->
   <policy context="default">
-    <allow send_destination="org.deepin.dde.Face1"/>
-
+    <allow send_destination="org.deepin.dde.Face1"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.deepin.dde.Face1"
+           send_interface="org.freedesktop.DBus.Peer"/>
+    <allow send_destination="org.deepin.dde.Face1"
+           send_interface="org.freedesktop.DBus.Properties"/>
+    <deny send_destination="org.deepin.dde.Face1"
+          send_interface="org.deepin.dde.Face1"/>
   </policy>
-  <policy user="deepin-daemon">
-    <allow own="org.deepin.dde.Face1"/>
-    <allow send_destination="org.deepin.dde.Face1" />
+
+  <!-- deepin-daemon group can call everything -->
+  <policy group="deepin-daemon">
+    <allow send_destination="org.deepin.dde.Face1"/>
+    <allow receive_sender="org.deepin.dde.Face1"/>
+  </policy>
+
+  <!-- Root can call everything -->
+  <policy user="root">
+    <allow send_destination="org.deepin.dde.Face1"/>
+    <allow receive_sender="org.deepin.dde.Face1"/>
   </policy>
 
 </busconfig>


### PR DESCRIPTION
## Summary

`org.deepin.dde.Face1` DBus policy allowed any local user to call all methods including `EnrollStart`/`VerifyStart`/`Delete` via `<policy context=\default\><allow send_destination=\org.deepin.dde.Face1\/></policy>`.

**Fix:** Tighten the default policy to only permit standard DBus interfaces (Introspectable/Peer/Properties), deny the `org.deepin.dde.Face1` interface for unprivileged users. `deepin-daemon` group and `root` retain full access.

## Changes

`msic/dbus-conf/org.deepin.dde.Face1.conf` — DBus policy:
- Default context: allow Introspectable/Peer/Properties, deny Face1 interface
- `deepin-daemon` group: allow everything
- `root`: allow everything

## Rationale

The actual callers of Face1 are:
1. `deepin-authentication` (runs as root, already has its own caller authorization via commit `Ia92a3cdb`)
2. Processes that go through `deepin-security-loader` (attaches `deepin-daemon` group)

No end-user application directly calls `org.deepin.dde.Face1`.

## Verification

Tested on debug machine (10.20.9.188):

| Method | uos (regular user) | root |
|--------|-------------------|------|
| `EnrollStart` | `Access denied` | ✅ passes |
| `EnrollStop` | `Access denied` | ✅ passes |
| `VerifyStart` | `Access denied` | ✅ passes |
| `VerifyStop` | `Access denied` | ✅ passes |
| `Delete` | `Access denied` | ✅ passes |
| `getClaim` | ✅ works | ✅ works |
| `getList` | ✅ works | ✅ works |
| `getCharaType` | ✅ works | ✅ works |

PMS: BUG-364733
Influence: 普通用户不再能直接通过 qdbus/busctl 调用 Face1 敏感方法

## Summary by Sourcery

Restrict DBus access to the org.deepin.dde.Face1 interface so only root and deepin-daemon processes can invoke its methods while regular users are limited to standard DBus interfaces.

Bug Fixes:
- Prevent unprivileged local users from directly invoking sensitive org.deepin.dde.Face1 methods over DBus by tightening the default policy.

Enhancements:
- Grant the deepin-daemon group and root explicit full DBus access to org.deepin.dde.Face1, including send and receive permissions.