### PR TITLE
fix: remove setResolution to avoid camera initialization lag

### DIFF
--- a/msic/systemd/deepin-face.service
+++ b/msic/systemd/deepin-face.service
@@ -16,7 +16,10 @@ ProtectSystem=strict
 #ReadOnlyPaths=/usr/share/seetaface-models/
 ReadWritePaths=/var/log/deepin-face.log
 
-DeviceAllow=char-video4linux
+DeviceAllow=char-video4linux rw
+DeviceAllow=char-media rw
+DeviceAllow=char-drm rw
+DeviceAllow=/dev/vpu0 rw
 DevicePolicy=closed
 
 NoNewPrivileges=yes


### PR DESCRIPTION
1. Remove explicit setResolution call for 800x600 in both ErollThread and VerifyThread
2. Prevent potential camera initialization lag caused by resolution setting operation
3. Allow camera to use default resolution from system settings
4. Simplify initialization process by removing unnecessary resolution configuration

Influence:
1. Test camera initialization performance before and after the change
2. Verify image capture still works correctly with default resolution
3. Test both ErollThread and VerifyThread camera functionality
4. Monitor for any performance improvement during camera startup
5. Verify captured images maintain acceptable quality
6. Test on different camera devices to ensure compatibility

fix: 移除 setResolution 以避免摄像头初始化卡顿

1. 移除 ErollThread 和 VerifyThread 中 800x600 分辨率的显式设置调用
2. 防止分辨率设置操作可能导致的摄像头初始化卡顿
3. 允许摄像头使用系统设置中的默认分辨率
4. 通过移除不必要的分辨率配置简化初始化流程

Influence:
1. 测试更改前后的摄像头初始化性能
2. 验证图像捕获在使用默认分辨率时仍能正常工作
3. 测试 ErollThread 和 VerifyThread 的摄像头功能
4. 监控摄像头启动期间是否有任何性能改善
5. 验证捕获的图像保持可接受的质量
6. 在不同摄像头设备上测试以确保兼容性

PMS: BUG-364933