### PR TITLE
chore: update device permissions for systemd service

### DIFF
--- a/msic/systemd/deepin-face.service
+++ b/msic/systemd/deepin-face.service
@@ -16,7 +16,10 @@ ProtectSystem=strict
 #ReadOnlyPaths=/usr/share/seetaface-models/
 ReadWritePaths=/var/log/deepin-face.log
 
-DeviceAllow=char-video4linux
+DeviceAllow=char-video4linux rw
+DeviceAllow=char-media rw
+DeviceAllow=char-drm rw
+DeviceAllow=/dev/vpu0 rw
 DevicePolicy=closed
 
 NoNewPrivileges=yes


### PR DESCRIPTION
In the deepin-face.service file, modify the DeviceAllow directive to grant read-write access for char-video4linux, and add new allowances for char-media, char-drm, and /dev/vpu0 with read-write permissions. This change ensures that the deepin-face service can access necessary hardware devices for its functionality, such as video capture, media processing, and graphics rendering, which may be required for proper operation.

Influence:
1. Test that the deepin-face service starts successfully with the updated device permissions.
2. Verify access to video devices (/dev/video4linux*), media devices (/ dev/media*), DRM devices (/dev/dri/*), and the specific device /dev/ vpu0.
3. Ensure the service operates correctly when using camera or graphics resources.
4. Confirm that permissions are appropriately scoped and do not introduce security vulnerabilities.

chore: 更新系统服务的设备权限

在 deepin-face.service 文件中，更新 DeviceAllow 指令，为 char- video4linux 授予读写权限，并添加对 char-media、char-drm 和 /dev/vpu0 的 读写权限。此更改确保 deepin-face 服务能够访问其功能所需的硬件设备，如视
频捕获、媒体处理和图形渲染，这对于正常运行可能是必要的。

Influence:
1. 测试 deepin-face 服务在更新设备权限后能否正常启动。
2. 验证对视频设备、媒体设备、DRM 设备和特定设备 /dev/vpu0 的访问权限。
3. 确保服务在使用摄像头或图形资源时正常运行。
4. 确认权限范围适当，不会引入安全漏洞。

PMS: BUG-364933