### PR TITLE
chore: update changelog to 2.0.15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-face (2.0.15) unstable; urgency=medium
+
+  * chore: update device permissions for systemd service
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:17:11 +0800
+
 deepin-face (2.0.14) unstable; urgency=medium
 
   * fix: 收紧 DBus policy 限制普通用户直接调用 Face1 敏感接口


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.15

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.15
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.15 targeting the master branch.